### PR TITLE
adding crackwatch subdomain

### DIFF
--- a/releases/hosts
+++ b/releases/hosts
@@ -2625,7 +2625,7 @@
 216.118.89.130 iafd.com www.iafd.com
 
 # [crackwatch.com]
-104.26.12.70 crackwatch.com www.crackwatch.com b2.crackwatch.com cron.crackwatch.com
+104.26.12.70 crackwatch.com www.crackwatch.com b2.crackwatch.com cron.crackwatch.com s3.crackwatch.com
 
 # [lookmovie.ag]
 104.31.1.179 lookmovie.ag www.lookmovie.ag


### PR DESCRIPTION
Some images are served from s3.crackwatch.com