### PR TITLE
Update binance.com, added binance.org (issue #282)

### DIFF
--- a/releases/hosts
+++ b/releases/hosts
@@ -4652,6 +4652,17 @@
 52.84.229.70 c2c.binance.com
 52.84.229.69 c2c.binance.com
 52.84.150.34 academy.binance.com
+
+# [binance.org]
+52.84.229.114 bsc-dataseed.binance.org
+52.84.229.7 bsc-dataseed.binance.org
+52.84.229.69 bsc-dataseed.binance.org
+52.84.229.97 bsc-dataseed.binance.org
+52.84.229.104 bsc-dataseed1.binance.org
+52.84.229.36 bsc-dataseed1.binance.org
+52.84.229.57 bsc-dataseed1.binance.org
+52.84.229.68 bsc-dataseed1.binance.org
+
 # [peacetv.tv]
 95.131.68.14 peacetv.tv www.peacetv.tv mail.peacetv.tv ftp.peacetv.tv
 

--- a/releases/hosts
+++ b/releases/hosts
@@ -4643,7 +4643,15 @@
 52.68.175.51 launchpad-0-0.binance.com
 13.112.57.27 binance.com
 52.84.150.34 www.binance.com
-
+52.84.229.63 ftp.binance.com
+52.84.229.30 ftp.binance.com
+52.84.229.21 ftp.binance.com
+52.84.229.29 ftp.binance.com
+52.84.229.117 c2c.binance.com
+52.84.229.30 c2c.binance.com
+52.84.229.70 c2c.binance.com
+52.84.229.69 c2c.binance.com
+52.84.150.34 academy.binance.com
 # [peacetv.tv]
 95.131.68.14 peacetv.tv www.peacetv.tv mail.peacetv.tv ftp.peacetv.tv
 


### PR DESCRIPTION
Memperbaiki beberapa subdomain dari binance (ftp, c2c, academy) yang sebelumnya tidak bisa dibuka dan menambahkan alamat baru: bsc-dataseed.binance.org yang dapat digunakan sebagai Binance Smart Chain Mainnet.