### PR TITLE
Update browser option untuk non-chrome Linux user

### DIFF
--- a/releases/bebasid.sh
+++ b/releases/bebasid.sh
@@ -530,7 +530,11 @@ mulai_bebasid_tunnel(){
           ;;
         esac
       loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-      tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+      if [[ "$browser" == "firefox" ]]; then
+        tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random -ProfileManager" Enter
+      else
+        tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+      fi
       fi	
       ;;	
     Darwin* )	

--- a/releases/bebasid.sh
+++ b/releases/bebasid.sh
@@ -435,6 +435,16 @@ cek_perintah_tunnel(){
     errorin "Tmux tidak terpasang, silakan pasang Tmux terlebih dahulu"	
   fi	
 }	
+pilih_browser() {
+  echo "=========================="
+  echo "      PILIH BROWSER       "
+  echo "=========================="
+  echo "1. Google Chrome"
+  echo "2. Firefox"
+  echo "3. Brave Browser"
+  echo -n "Pilih 1-3: "
+
+}
 mulai_bebasid_tunnel(){	
   getUname=$(uname -s)	
   case $getUname in	
@@ -493,15 +503,38 @@ mulai_bebasid_tunnel(){
       if [[ "$browser" == "no" ]]; then	
         tmux send-keys -t 2 "bebasid tunnel bebasid-tunnel-nb" Enter	
       else	
-        if [[ -x $(command -v google-chrome-stable) ]]; then	
-          browser="google-chrome-stable"	
-          killall chrome	
-        elif [[ -x $(command -v google-chrome) ]]; then	
-          browser="google-chrome"	
-          killall chrome	
-        fi	
+        pilih_browser
+        read number
+        case $number in
+        1)
+          if [[ -x $(command -v google-chrome-stable) ]]; then	
+            browser="google-chrome-stable"	
+            killall chrome	
+          elif [[ -x $(command -v google-chrome) ]]; then	
+            browser="google-chrome"	
+            killall chrome	
+          fi	
+            loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
+            tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+          ;;
+        2)
+          browser="firefox"
+          killall firefox
           loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-          tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter	
+          tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+          ;;
+        3)
+          if [[ -x $(command -v brave-browser-stable) ]]; then	
+            browser="brave-browser-stable"	
+            killall brave	
+          elif [[ -x $(command -v brave-browser) ]]; then	
+            browser="brave-browser"	
+            killall brave	
+          fi	
+            loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
+            tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+          ;;
+        esac
       fi	
       ;;	
     Darwin* )	

--- a/releases/bebasid.sh
+++ b/releases/bebasid.sh
@@ -526,9 +526,7 @@ mulai_bebasid_tunnel(){
           elif [[ -x $(command -v brave-browser) ]]; then	
             browser="brave-browser"	
             killall brave	
-          fi	
-            loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-            tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+          fi
           ;;
         esac
       loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	

--- a/releases/bebasid.sh
+++ b/releases/bebasid.sh
@@ -513,15 +513,11 @@ mulai_bebasid_tunnel(){
           elif [[ -x $(command -v google-chrome) ]]; then	
             browser="google-chrome"	
             killall chrome	
-          fi	
-            loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-            tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+          fi
           ;;
         2)
           browser="firefox"
           killall firefox
-          loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-          tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
           ;;
         3)
           if [[ -x $(command -v brave-browser-stable) ]]; then	
@@ -535,6 +531,8 @@ mulai_bebasid_tunnel(){
             tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
           ;;
         esac
+      loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
+      tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
       fi	
       ;;	
     Darwin* )	

--- a/releases/bebasid.sh
+++ b/releases/bebasid.sh
@@ -513,6 +513,9 @@ mulai_bebasid_tunnel(){
           elif [[ -x $(command -v google-chrome) ]]; then	
             browser="google-chrome"	
             killall chrome	
+          else
+            tmux send-keys -t 1 C-c
+            errorin "Browser tidak ditemukan"
           fi
           ;;
         2)
@@ -526,15 +529,26 @@ mulai_bebasid_tunnel(){
           elif [[ -x $(command -v brave-browser) ]]; then	
             browser="brave-browser"	
             killall brave	
+          else
+            tmux send-keys -t 1 C-c
+            errorin "Browser tidak ditemukan"
           fi
           ;;
+        *)
+          tmux send-keys -t 1 C-c
+          errorin "Browser tidak dipilih"
         esac
       loadin 0.01 "Tunggu sebentar, sedang membuka $browser"	
-      if [[ "$browser" == "firefox" ]]; then
-        tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random -ProfileManager" Enter
-      else
-        tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
-      fi
+        if [[ "$browser" == "firefox" ]]; then
+          firefox -CreateProfile bebasit
+          firefoxDir=$(ls $HOME/.mozilla/firefox/ | grep bebasit)
+          rm -rf $HOME/.mozilla/firefox/$firefoxDir/prefs.js
+          touch $HOME/.mozilla/firefox/$firefoxDir/prefs.js
+          echo -e 'user_pref("network.proxy.http", "127.0.0.1");\nuser_pref("network.proxy.http_port", '$random');\nuser_pref("network.proxy.type", 1);' > $HOME/.mozilla/firefox/$firefoxDir/prefs.js
+          tmux send-keys -t 2 "$browser netflix.com -P bebasit" Enter
+        else
+          tmux send-keys -t 2 "$browser netflix.com --proxy-server=127.0.0.1:$random" Enter
+        fi
       fi	
       ;;	
     Darwin* )	


### PR DESCRIPTION
Update untuk non-chrome Linux user.
Sejauh ini hanya masih tersedia 3 opsi: Google Chrome, Firefox, dan Brave Browser.

Tested on: 
OS:       Ubuntu 20.04. LTS
Kernel: 5.8.0-41-generic

Test preview
Command:
![image](https://user-images.githubusercontent.com/32705957/107198591-dd0fc880-6a27-11eb-8d2d-3dcd0cbf85ff.png)

Browser:
![image](https://user-images.githubusercontent.com/32705957/107198836-30821680-6a28-11eb-8ff8-9cdcd685b121.png)

Tmux tunnel
![image](https://user-images.githubusercontent.com/32705957/107198692-06c8ef80-6a28-11eb-936d-c81eb12bdb1b.png)
