### PR TITLE
Update link hosts untuk Android pada dokumentasi

### DIFF
--- a/dev/readme/USAGE.md
+++ b/dev/readme/USAGE.md
@@ -22,7 +22,7 @@ Alternatif (jika ingin install melewati aplikasi atau menambahkan list hosts lai
 Install aplikasi [AdAway](https://f-droid.org/en/packages/org.adaway)
 
 ```
-https://raw.githubusercontent.com/bebasid/bebasid/master/dev/resources/hosts.android
+https://raw.githubusercontent.com/bebasid/bebasid/master/releases/hosts
 ```
 
 Buka aplikasinya, pilih Add, kemudian salin kode diatas lalu tambahkan.


### PR DESCRIPTION
Hosts file untuk Android pada [bebasid/dev/resources/hosts.android](https://raw.githubusercontent.com/bebasid/bebasid/master/dev/resources/hosts.android) sepertinya sudah lama tidak update dan beberapa hosts telah mengalami update pada file [bebasid/releases/hosts](https://raw.githubusercontent.com/bebasid/bebasid/master/releases/hosts). Telah dicoba di Android 11 (rooted) menggunakan AdAway.