### PR TITLE
Add www.animekai.to and static.animekai.to to hosts (#714)

### DIFF
--- a/releases/hosts
+++ b/releases/hosts
@@ -26035,6 +26035,7 @@
 # [naughtymachinima.com]
 69.16.244.64 www.naughtymachinima.com
 
-
 # [animekai.to]
 104.21.73.25 animekai.to
+172.67.137.247 www.animekai.to
+172.67.137.247 static.animekai.to


### PR DESCRIPTION
Adds missing subdomains for animekai.to that were still blocked after the main domain was added.

Changes:
- Added `www.animekai.to` → `172.67.137.247`
- Added `static.animekai.to` → `172.67.137.247` (images were not loading due to subdomain being blocked, reported by @Username778)

Refs #714