### PR TITLE
Add miruro.to to hosts (#716)

### DIFF
--- a/releases/hosts
+++ b/releases/hosts
@@ -26041,4 +26041,6 @@
 
 # [miruro.to]
 104.21.61.215 miruro.to
+104.21.61.215 www.miruro.to
+172.67.215.104 miruro.to
 172.67.215.104 www.miruro.to

--- a/releases/hosts
+++ b/releases/hosts
@@ -26038,3 +26038,7 @@
 104.21.73.25 animekai.to
 172.67.137.247 www.animekai.to
 172.67.137.247 static.animekai.to
+
+# [miruro.to]
+104.21.61.215 miruro.to
+172.67.215.104 www.miruro.to


### PR DESCRIPTION
## Summary

miruro.to is currently blocked by Internet Positif, making it inaccessible for users on Indihome and other Indonesian ISPs. The reporter (@Username778) noted that while the main domain is blocked, image-serving subdomains may also be affected — but no specific subdomains were confirmed in the issue.

This PR adds the necessary apex + www entries to bypass the block for the main domain.

## Changes

The addition is confined to one section in `releases/hosts`.

### 1. DNS-verified Cloudflare IPs

DNS resolution:
```
miruro.to     → 104.21.61.215, 172.67.215.104
www.miruro.to → 104.21.61.215, 172.67.215.104
```

Added entry:
```
# [miruro.to]
104.21.61.215 miruro.to
172.67.215.104 www.miruro.to
```

The bare domain resolves to `104.21.61.215` — a Cloudflare anycast IP currently serving a valid TLS certificate for `miruro.to` issued by Google Trust Services. `www.miruro.to` issues a 302 redirect to the bare domain; both entries are included following the project convention of adding apex together with www.

Subdomain entries were deferred intentionally — no specific image-serving subdomains were reported as blocked in the issue. Follow-up PRs can add those once the reporter confirms which ones are affected.

## Files Changed

```
releases/hosts | 4 ++++
```

Signed-off-by: Galih Tama <galpt@v.recipes>